### PR TITLE
Fix SonarQube Maintainability Issue — Replace System.out with Logger in ByteStrings.java

### DIFF
--- a/examples/src/main/java/com/squareup/moshi/recipes/ByteStrings.java
+++ b/examples/src/main/java/com/squareup/moshi/recipes/ByteStrings.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.squareup.moshi.recipes;
 
 import com.squareup.moshi.JsonAdapter;
@@ -20,22 +21,31 @@ import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import java.io.IOException;
+import java.util.logging.Logger;
 import okio.ByteString;
 
 public final class ByteStrings {
+
+  // Add a logger for this class
+  private static final Logger logger = Logger.getLogger(ByteStrings.class.getName());
+
   public void run() throws Exception {
     String json = "\"TW9zaGksIE9saXZlLCBXaGl0ZSBDaGluPw\"";
 
     Moshi moshi = new Moshi.Builder().add(ByteString.class, new Base64ByteStringAdapter()).build();
     JsonAdapter<ByteString> jsonAdapter = moshi.adapter(ByteString.class);
-
     ByteString byteString = jsonAdapter.fromJson(json);
-    System.out.println(byteString);
+
+    // Old:
+    // System.out.println(byteString);
+
+    // New (SonarQube-compliant)
+    logger.info(byteString.toString());
   }
 
   /**
-   * Formats byte strings using <a href="http://www.ietf.org/rfc/rfc2045.txt">Base64</a>. No line
-   * breaks or whitespace is included in the encoded form.
+   * Formats byte strings using <a href="http://www.ietf.org/rfc/rfc2045.txt">Base64</a>.
+   * No line breaks or whitespace is included in the encoded form.
    */
   public final class Base64ByteStringAdapter extends JsonAdapter<ByteString> {
     @Override


### PR DESCRIPTION
This pull request fixes the SonarQube issue (java:S106) in ByteStrings.java by replacing System.out.println() with a Logger.

- Added Logger import
- Declared a static Logger instance
- Used logger.info() instead of System.out.println()
- Resolves Technical Debt Fix: Replace System.out.println() with Logger
