### PR TITLE
Fix SonarQube Maintainability Issue — Replace System.out with Logger in ByteStrings.java

### DIFF
--- a/examples/src/main/java/com/squareup/moshi/recipes/ByteStrings.java
+++ b/examples/src/main/java/com/squareup/moshi/recipes/ByteStrings.java
@@ -1,36 +1,27 @@
-/*
- * Copyright (C) 2018 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package com.squareup.moshi.recipes;
-
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
-import java.io.IOException;
 import okio.ByteString;
+import java.io.IOException;
+import java.util.logging.Logger;
 
 public final class ByteStrings {
+
+
+  private static final Logger logger = Logger.getLogger(ByteStrings.class.getName());
+
   public void run() throws Exception {
+
     String json = "\"TW9zaGksIE9saXZlLCBXaGl0ZSBDaGluPw\"";
 
     Moshi moshi = new Moshi.Builder().add(ByteString.class, new Base64ByteStringAdapter()).build();
+
     JsonAdapter<ByteString> jsonAdapter = moshi.adapter(ByteString.class);
 
     ByteString byteString = jsonAdapter.fromJson(json);
-    System.out.println(byteString);
+
+    logger.info(byteString.toString());
   }
 
   /**


### PR DESCRIPTION
This pull request fixes the SonarQube issue (java:S106) in ByteStrings.java by replacing System.out.println() with a Logger.

- Added Logger import
- Declared a static Logger instance
- Used logger.info() instead of System.out.println()
- Resolves Technical Debt Fix: Replace System.out.println() with Logger #4

