### PR TITLE
Replaced System.out.println with Logger in CustomFieldName.java

### DIFF
--- a/examples/src/main/java/com/squareup/moshi/recipes/CustomFieldName.java
+++ b/examples/src/main/java/com/squareup/moshi/recipes/CustomFieldName.java
@@ -18,8 +18,13 @@ package com.squareup.moshi.recipes;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.recipes.models.Player;
+import java.util.logging.Logger;
 
 public final class CustomFieldName {
+
+  // Declare a static logger instance for this class
+  private static final Logger logger = Logger.getLogger(CustomFieldName.class.getName());
+
   public void run() throws Exception {
     String json = "" + "{" + "  \"username\": \"jesse\"," + "  \"lucky number\": 32" + "}\n";
 
@@ -27,10 +32,16 @@ public final class CustomFieldName {
     JsonAdapter<Player> jsonAdapter = moshi.adapter(Player.class);
 
     Player player = jsonAdapter.fromJson(json);
-    System.out.println(player);
+
+    //  Used logger instead of System.out.println()
+    logger.info(player.toString());
   }
 
   public static void main(String[] args) throws Exception {
     new CustomFieldName().run();
   }
 }
+
+
+
+


### PR DESCRIPTION
Description:
This pull request addresses a maintainability issue reported by SonarQube (java rule:S106) in CustomFieldName.java. The direct usage of System.out.println() has been replaced with a proper logging mechanism using java.util.logging.Logger.

Reason for Change:
System.out.println() provides no control over log levels or output formatting.
Using a logger improves maintainability, consistency, and production readiness.

Changes Made:
Added a static Logger instance to the CustomFieldName class.
Replaced all System.out.println() calls with logger.info() (or appropriate log level).
Verified that the logging output remains readable and clear.