### PR TITLE
Remove jacoco coverage report path from sonarcloud.yml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -59,6 +59,5 @@ jobs:
             -Dsonar.organization=dhruvilshah00
             -Dsonar.java.binaries=${{ steps.gather-binaries.outputs.binaries }}
             -Dsonar.junit.reportPaths=**/build/test-results/test
-            -Dsonar.coverage.jacoco.xmlReportPaths=**/build/reports/jacoco/test/jacocoTestReport.xml
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Removed jacoco coverage report path from SonarCloud configuration.