### PR TITLE
Remove junit report paths from sonarcloud.yml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -58,6 +58,5 @@ jobs:
             -Dsonar.projectKey=Dhruvilshah00_moshi
             -Dsonar.organization=dhruvilshah00
             -Dsonar.java.binaries=${{ steps.gather-binaries.outputs.binaries }}
-            -Dsonar.junit.reportPaths=**/build/test-results/test
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Removed the junit report paths from SonarCloud configuration.