### PR TITLE
Fix variable shadowing by renaming local buffer to tempBuffer in JsonCodecFactory

### DIFF
--- a/moshi/src/test/java/com/squareup/moshi/JsonCodecFactory.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonCodecFactory.java
@@ -32,8 +32,9 @@ abstract class JsonCodecFactory {
 
           @Override
           public JsonReader newReader(String json) {
-            Buffer buffer = new Buffer().writeUtf8(json);
-            return JsonReader.of(buffer);
+            //changed the name from buffer to tempBuffer
+            Buffer tempBuffer = new Buffer().writeUtf8(json);
+            return JsonReader.of(tempBuffer);
           }
 
           @Override


### PR DESCRIPTION
This pull request addresses a maintainability code smell reported by SonarCloud in JsonCodecFactory.java.
A local variable named buffer inside the newReader() method was shadowing a class-level field declared at line 31.

To improve code clarity and prevent potential confusion, the local variable has been renamed to tempBuffer.
This small refactor enhances readability and aligns with clean coding practices by avoiding variable shadowing.

Details:

File modified: moshi/src/main/java/com/squareup/moshi/JsonCodecFactory.java
Renamed buffer → tempBuffer in the newReader() method
Verified build remains stable and all tests pass
SonarCloud issue reference:
“Rename 'buffer' which hides the field declared at line 31.”