### PR TITLE
Update AdapterMethodsFactory adapter behavior

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.kt
+++ b/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.kt
@@ -321,14 +321,19 @@ internal class AdapterMethodsFactory(
     private val adaptersOffset: Int,
     type: Type,
     parameterCount: Int,
-    val annotations: Set<Annotation>,
+    annotations: Set<Annotation>,
     val adapter: Any,
     val method: Method,
     val nullable: Boolean,
   ) {
-    val type = type.canonicalize()
-    private val jsonAdapters: Array<JsonAdapter<*>?> = arrayOfNulls(parameterCount - adaptersOffset)
+    private val internalAnnotations: Set<Annotation> = annotations.toSet()
 
+    val annotations: Set<Annotation>
+      get() = internalAnnotations.toSet()
+
+    val type = type.canonicalize()
+    private val jsonAdapters: Array<JsonAdapter<*>?> =
+      arrayOfNulls(parameterCount - adaptersOffset)
     open fun bind(moshi: Moshi, factory: JsonAdapter.Factory) {
       if (jsonAdapters.isNotEmpty()) {
         val parameterTypes = method.genericParameterTypes
@@ -345,9 +350,7 @@ internal class AdapterMethodsFactory(
         }
       }
     }
-
     open fun toJson(moshi: Moshi, writer: JsonWriter, value: Any?): Unit = throw AssertionError()
-
     open fun fromJson(moshi: Moshi, reader: JsonReader): Any? = throw AssertionError()
 
     /** Invoke the method with one fixed argument, plus any number of JSON adapter arguments. */


### PR DESCRIPTION
**Summary**
Refine AdapterMethodsFactory.AdapterMethod so that it no longer exposes its internal annotations set directly. This addresses a SpotBugs finding (EI_EXPOSE_REP, CWE-374) reported as a malicious code vulnerability.

**Background / Motivation**
Running SpotBugs on the project flagged:

Pattern: EI_EXPOSE_REP – May expose internal representation by returning reference to mutable object

CWE: 374 – Passing Mutable Objects to an Untrusted Method

Location: moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.kt, class AdapterMethodsFactory.AdapterMethod

The constructor previously declared annotations as a val, which generates a getter that returns the backing Set<Annotation> field directly. If the set is mutable, callers can modify it and therefore mutate the internal state of AdapterMethod.

**Changes**

Changed the AdapterMethod constructor to take annotations as a regular parameter instead of a val.

Introduced a private field:
`private val internalAnnotations: Set<Annotation> = annotations.toSet()
`
Re-exposed annotations via a property that returns a defensive copy:
```

val annotations: Set<Annotation>
  get() = internalAnnotations.toSet()

```
Kept the rest of AdapterMethod behavior unchanged (binding logic, delegation, toJson/fromJson helpers, etc.).

Ran Kotlin formatting tasks so that the updated file passes Spotless checks.

This preserves the existing API (val annotations: Set<Annotation>) while preventing external callers from mutating the internal representation.


Closes #<39>