### PR TITLE
SpotBugs: Avoid exposing internal representation in JsonValueReader.JsonIterator

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.kt
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.kt
@@ -396,15 +396,15 @@ internal class JsonValueReader : JsonReader {
 
   internal class JsonIterator(
     val endToken: Token,
-    val array: Array<Any?>,
-    var next: Int,
+    private val array: Array<Any?>,
+    private var next: Int,
   ) : Iterator<Any?>,
     Cloneable {
     override fun hasNext() = next < array.size
 
     override fun next() = array[next++]
 
-    // No need to copy the array; it's read-only.
+    // No need to copy the array; it's read-only from outside this class.
     public override fun clone() = JsonIterator(endToken, array, next)
   }
 }


### PR DESCRIPTION
**Summary**
SpotBugs detected a Malicious Code warning (EI_EXPOSE_REP, mapped to CWE-374) in JsonValueReader.JsonIterator.
The iterator previously exposed its internal array field via an auto-generated Kotlin getter, allowing external mutation of the internal backing array.

**Problem**
The class originally declared:
val array: Array<Any?>

Since arrays are mutable, exposing them publicly violates SpotBugs’ encapsulation checks. Callers could modify the array contents:
iterator.array[0] = modifiedValue
This breaks internal assumptions, potentially corrupting iteration order or behavior. Although JsonIterator is internal, SpotBugs correctly treats this as unsafe exposure.

**Fix**
Convert the array property to private:
private val array: Array<Any?>
This prevents Kotlin from generating a public getter and ensures no external code can mutate the backing array.
No API changes and no behavioral differences.

**Result**
✔ Eliminates SpotBugs EI_EXPOSE_REP warning
✔ Restores proper encapsulation
✔ Maintains existing iterator behavior