### PR TITLE
Refactor Moshi.Builder to use private mutableFactories

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Moshi.kt
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.kt
@@ -189,12 +189,17 @@ public class Moshi internal constructor(builder: Builder) {
   }
 
   public class Builder {
-    internal val factories = mutableListOf<JsonAdapter.Factory>()
+    private val mutableFactories = mutableListOf<JsonAdapter.Factory>()
+
+    internal val factories: List<JsonAdapter.Factory>
+      get() = mutableFactories.toList()
+
     internal var lastOffset = 0
 
     @CheckReturnValue
     @ExperimentalStdlibApi
-    public inline fun <reified T> addAdapter(adapter: JsonAdapter<T>): Builder = add(typeOf<T>().javaType, adapter)
+    public inline fun <reified T> addAdapter(adapter: JsonAdapter<T>): Builder =
+      add(typeOf<T>().javaType, adapter)
 
     public fun <T> add(type: Type, jsonAdapter: JsonAdapter<T>): Builder = apply {
       add(newAdapterFactory(type, jsonAdapter))
@@ -209,7 +214,7 @@ public class Moshi internal constructor(builder: Builder) {
     }
 
     public fun add(factory: JsonAdapter.Factory): Builder = apply {
-      factories.add(lastOffset++, factory)
+      mutableFactories.add(lastOffset++, factory)
     }
 
     public fun add(adapter: Any): Builder = apply {
@@ -231,7 +236,7 @@ public class Moshi internal constructor(builder: Builder) {
     }
 
     public fun addLast(factory: JsonAdapter.Factory): Builder = apply {
-      factories.add(factory)
+      mutableFactories.add(factory)
     }
 
     @Suppress("unused")


### PR DESCRIPTION
This pull request fixes a SpotBugs Malicious Code warning (EI_EXPOSE_REP, mapped to CWE-374) in Moshi.Builder.

The builder previously exposed its internal mutable factories list via an automatically generated accessor. This allowed external code within the module or Java callers to directly mutate the internal builder state, potentially violating builder invariants such as lastOffset and causing unexpected adapter ordering.

The fix introduces a private mutable backing list and exposes only an immutable snapshot of the factories. All modifications are now restricted to controlled builder methods (add, addLast), preventing external mutation while preserving existing behavior and API functionality.

This change restores encapsulation, eliminates the SpotBugs EI_EXPOSE_REP warning, and does not introduce any behavioral or performance regressions.